### PR TITLE
fix: Set default value to 'n' for the features flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,8 @@ CONFIG_VHT_EXTRAS = y
 CONFIG_LED_CONTROL = y
 CONFIG_LED_ENABLE = y
 CONFIG_USB2_EXTERNAL_POWER = y
-CONFIG_DISABLE_CHANNEL_ONE = y
-CONFIG_DISABLE_CCA = y
+CONFIG_DISABLE_CHANNEL_ONE = n
+CONFIG_DISABLE_CCA = n
 ########################## Debug ###########################
 CONFIG_RTW_DEBUG = n
 # default log level is _DRV_INFO_ = 4,


### PR DESCRIPTION
Set defautl value to 'n' for for the CONFIG_DISABLE_CCA and CONFIG_DISABLE_CHANNEL_ONE flags